### PR TITLE
Support GitHub Actions re-run failed jobs

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -21,6 +21,6 @@ runs:
         AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
         AWS_SESSION_TOKEN: ${{ steps.aws-credentials.outputs.aws-session-token }}
         ASSETS_NAME: ${{ inputs.name }}
-        ASSETS_BASE_PATH: assets/${{ steps.aws-credentials.outputs.subject }}/run:${{ env.GITHUB_RUN_ID }}/attempt:${{ env.GITHUB_RUN_ATTEMPT }}
+        ASSETS_BASE_PATH: assets/${{ steps.aws-credentials.outputs.subject }}/run:${{ env.GITHUB_RUN_ID }}
         BUCKET: incognia-github-actions-storage
       run: aws s3 cp "s3://${BUCKET}/${ASSETS_BASE_PATH}/${ASSETS_NAME}" - | tar -xvf -


### PR DESCRIPTION
When re-running failed jobs, the download-assets action fails if the upload-assets action only ran in the previous attempt.

Failed re-run example: https://github.com/inloco/incognia/runs/6158462855?check_suite_focus=true

This can be solved by removing the GITHUB_RUN_ATTEMPT from ASSETS_BASE_PATH.

Successful Test: https://github.com/inloco/actions-playground/actions/runs/2222067874